### PR TITLE
Bump pnet version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-pnet_macros = "0.31"
-pnet_macros_support = "0.31"
+pnet_macros = "0.34"
+pnet_macros_support = "0.34"
 
 [features]
 default = ["pnet", "rtp", "rtcp"]


### PR DESCRIPTION
This leads to `syn 1` getting dropped! 